### PR TITLE
Use expires_at property passed into accessToken.create.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Version Next
+* Does not override expires_at property if passed into accessToken.create.
+
 ## v0.8.0 (1 August 2016)
 * Upgraded code to strict mode.
 * Upgraded all the code base to es6.

--- a/lib/client/access-token.js
+++ b/lib/client/access-token.js
@@ -2,6 +2,8 @@
 
 const addSeconds = require('date-fns/add_seconds');
 const isAfter = require('date-fns/is_after');
+const isDate = require('date-fns/is_date');
+const parse = require('date-fns/parse');
 const coreModule = require('./../core');
 
 /**
@@ -12,9 +14,13 @@ module.exports = function (config) {
 
   function AccessToken(token) {
     this.token = token;
-    this.token.expires_at = addSeconds((new Date), token.expires_in);
-
-    return this;
+    if ('expires_at' in this.token) {
+      if (!isDate(this.token.expires_at)) {
+        this.token.expires_at = parse(this.token.expires_at);
+      }
+    } else {
+      this.token.expires_at = addSeconds(new Date(), token.expires_in);
+    }
   }
 
   /**

--- a/test/access_token.js
+++ b/test/access_token.js
@@ -2,8 +2,11 @@
 
 const qs = require('querystring');
 const nock = require('nock');
+const expect = require('chai').expect;
 const startOfYesterday = require('date-fns/start_of_yesterday');
 const oauth2Module = require('./../index.js');
+const isValid = require('date-fns/is_valid');
+const isEqual = require('date-fns/is_equal');
 
 const oauth2 = oauth2Module({
   clientID: 'client-id',
@@ -82,6 +85,29 @@ describe('oauth2.accessToken', function () {
 
     it('created an access token as result of promise api', function () {
       tokenPromise.should.have.property('token');
+    });
+  });
+
+  describe('#create with expires_at', function () {
+    it('uses the set expires_at property', function () {
+      token.token.expires_at = startOfYesterday();
+      const expiredToken = oauth2.accessToken.create(token.token);
+      expect(isValid(expiredToken.token.expires_at)).to.be.equal(true);
+      expect(isEqual(expiredToken.token.expires_at, token.token.expires_at))
+        .to.be.equal(true);
+    });
+
+    it('parses a set expires_at property', function () {
+      const yesterday = startOfYesterday();
+      token.token.expires_at = yesterday.toString();
+      const expiredToken = oauth2.accessToken.create(token.token);
+      expect(isValid(expiredToken.token.expires_at)).to.be.equal(true);
+      expect(isEqual(expiredToken.token.expires_at, token.token.expires_at))
+        .to.be.equal(true);
+    });
+
+    it('create its own date by default', function () {
+      expect(isValid(token.token.expires_at)).to.be.equal(true);
     });
   });
 
@@ -175,8 +201,13 @@ describe('oauth2.accessToken', function () {
       result.token.should.have.property('access_token');
     });
 
-    it('returns a new oauth2.accessToken as result of promise api', function () {
-      resultPromise.token.should.have.property('access_token');
+    it('returns a new oauth2.accessToken as result of callback api', function () {
+      expect(result.token).to.have.property('access_token');
+    });
+
+    it('returns a new oauth2.accessToken as a result of the token refresh', function () {
+      expect(result.token).to.have.property('access_token');
+      expect(resultPromise.token).to.have.property('access_token');
     });
   });
 


### PR DESCRIPTION
Based off of 8a65918 (version 0.8.0) with the fix to expiry from 1.0.0
